### PR TITLE
Fix callable function class

### DIFF
--- a/tests/callable_tests.cc
+++ b/tests/callable_tests.cc
@@ -13,3 +13,38 @@ TEST_CASE("Callable Function") {
 	CHECK(func(10, 10) == 40);
 	CHECK(capture == 20);
 }
+
+TEST_CASE("Callable Function mixed params") {
+	auto capture{0};
+	auto func = Function<int(int, float)>{[&capture](int a, float b) {
+		capture += 10;
+		return a + b + capture;
+	}};
+
+	CHECK(func(10, 10.f) == 30);
+	CHECK(capture == 10);
+	CHECK(func(10, 10.f) == 40);
+	CHECK(capture == 20);
+}
+
+TEST_CASE("Callable Function lots of params") {
+	struct A {
+		int a;
+		char b;
+		float d;
+		double e;
+	};
+	auto capture{0};
+	auto func = Function<int(int, float, char, A, A)>{[&capture](int a, float b, char x, A aa, A bb) {
+		capture += 10;
+		if (x == 'a')
+			return aa.a + bb.b + capture * 2.f;
+		else
+			return a + b + capture;
+	}};
+
+	CHECK(func(10, 10.f, 'x', {}, {2, 'b', 1.2f, 1.4}) == 30);
+	CHECK(capture == 10);
+	CHECK(func(10, 10.f, 'a', {}, {2, 'a', 1.2f, 1.4}) == 137);
+	CHECK(capture == 20);
+}

--- a/tests/callable_tests.cc
+++ b/tests/callable_tests.cc
@@ -1,0 +1,15 @@
+#include "doctest.h"
+#include "util/callable.hh"
+
+TEST_CASE("Callable Function") {
+	auto capture{0};
+	auto func = Function<int(int, int)>{[&capture](int a, int b) {
+		capture += 10;
+		return a + b + capture;
+	}};
+
+	CHECK(func(10, 10) == 30);
+	CHECK(capture == 10);
+	CHECK(func(10, 10) == 40);
+	CHECK(capture == 20);
+}

--- a/util/callable.hh
+++ b/util/callable.hh
@@ -104,19 +104,19 @@ public:
 
 	Ret call(Args... args) {
 		if (m_callback)
-			return m_callback(&m_data[0], std::forward<Args...>(args)...);
+			return m_callback(&m_data[0], std::forward<Args>(args)...);
 		return Ret();
 	}
 
 	Ret operator()(Args... args) {
-		return call(std::forward<Args...>(args)...);
+		return call(std::forward<Args>(args)...);
 	}
 
 private:
 	template<typename Callable>
 	static Ret invoke(void *object, Args... args) {
 		Callable &callable = *reinterpret_cast<Callable *>(object);
-		callable(std::forward<Args...>(args)...);
+		return callable(std::forward<Args>(args)...);
 	}
 
 	template<typename Callable>


### PR DESCRIPTION
Fixes callable function class which wouldn't compile for me. Is there a chance I was using it wrong? 

```c++
auto capture{0};
auto func = Function<int(int, int)>{[&capture](int a, int b) {
	capture += 10;
	return a + b + capture;
}};
auto out = func(10, 10); // no matching function call error
``` 

Also adds unit test 